### PR TITLE
Remove const for MessageKind

### DIFF
--- a/src/communications.ts
+++ b/src/communications.ts
@@ -10,7 +10,7 @@ declare global {
   }
 }
 
-export const enum MessageKind {
+export enum MessageKind {
   Share = "Share",
   Platform = "Platform",
   PlatformQuery = "PlatformQuery",


### PR DESCRIPTION
## What does this change?
Due to using babel under-the-hood via metro bundler, [Editions doesn't support const enums](https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats), so this declaration is being stripped out.
