### PR TITLE
Turn off tests when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.22"
+  },
+  "np": {
+    "tests": false
   }
 }


### PR DESCRIPTION
## What does this change?
By default, NP runs tests during publishing. This package does not currently have tests so this PR adds a flag to disable this step. 
