### PR TITLE
Move NP to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "homepage": "https://github.com/guardian/renditions#readme",
   "dependencies": {
-    "np": "^7.5.0",
     "typescript": "^4.1.3"
   },
   "devDependencies": {
-    "@types/node": "^14.14.22"
+    "@types/node": "^14.14.22",
+    "np": "^7.5.0"
   },
   "np": {
     "tests": false


### PR DESCRIPTION
## What does this change?
NP was erroneously added as a main dependancy rather than a dev dependancy. This shifts it to being a dev dependancy.